### PR TITLE
fix exit crash

### DIFF
--- a/game/engine/core/Engine.cpp
+++ b/game/engine/core/Engine.cpp
@@ -29,6 +29,7 @@ Engine::Engine(const std::string config) : running(true)
 
 Engine::~Engine()
 {
+	Engine::stopMusic();
 	if (window != nullptr)
 	{
 		delete window;

--- a/game/game/states/MenuState.cpp
+++ b/game/game/states/MenuState.cpp
@@ -87,7 +87,6 @@ void MenuState::onUpdate(Keyboard* keyboard)
 
 void MenuState::onDestroy()
 {
-	this->context->stopMusic();
 }
 
 bool MenuState::onClick(Widget* button)

--- a/game/game/states/PauseState.cpp
+++ b/game/game/states/PauseState.cpp
@@ -77,5 +77,4 @@ bool PauseState::onClick(Widget* button)
 
 void PauseState::onDestroy()
 {
-	this->context->stopMusic();
 }


### PR DESCRIPTION
De destructor van Engine werd al aangeroepen voordat de onDestroy werd aangeroepen. we stoppen nu gewoon de muziek in de engine destructor